### PR TITLE
Update MANIFEST.MF

### DIFF
--- a/src/main/resources/archetype-resources/__package__.ui/META-INF/MANIFEST.MF
+++ b/src/main/resources/archetype-resources/__package__.ui/META-INF/MANIFEST.MF
@@ -1,6 +1,7 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
+#set($ActivatorName = $techName.substring(0,1).toUpperCase() + $techName.substring(1))
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ${package}.ui
@@ -30,4 +31,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: ${basePackage}.ui.quickfix,
  ${basePackage}.ui.contentassist,
  ${package}.ui.internal
-Bundle-Activator: ${package}.ui.internal.HerolanguageActivator
+Bundle-Activator: ${package}.ui.internal.${ActivatorName}Activator

--- a/src/main/resources/archetype-resources/__package__.ui/META-INF/MANIFEST.MF
+++ b/src/main/resources/archetype-resources/__package__.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-#set($ActivatorName = $techName.substring(0,1).toUpperCase() + $techName.substring(1))
+#set($ActivatorName = $dslExtension.substring(0,1).toUpperCase() + $dslExtension.substring(1))
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ${package}.ui


### PR DESCRIPTION
Fix: Bundle the right Activator for your language:
before fix:
Bundle-Activator: ${package}.ui.internal.HerolanguageActivator
now:
...
#set($ActivatorName = $techName.substring(0,1).toUpperCase() + $techName.substring(1))
...
Bundle-Activator: ${package}.ui.internal.${ActivatorName}Activator

Info: I dont know if this actually IS the way the Activators name is calculated, but it works in my scenario.